### PR TITLE
CI Working Solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 ### Collaborators
 [Avision Ho](https://github.com/avisionh)
+
 [Le Duong](https://github.com/ledu1993)
 
 # Update

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![Travis-CI Build Status](https://travis-ci.org/avisionh/Preference-Allocation.svg?branch=master)](https://travis-ci.org/avisionh/Preference-Allocation)
 
 ### Collaborators
-[Avision Ho](https://github.com/avisionh)
 
-[Le Duong](https://github.com/ledu1993)
+- [Avision Ho](https://github.com/avisionh)
+- [Le Duong](https://github.com/ledu1993)
 
 # Update
 - A Shiny app is being built for this problem.

--- a/_build.sh
+++ b/_build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env Rscript
 
-rmarkdown::render("index.Rmd")
+rmarkdown::render("docs/index.Rmd")

--- a/_deploy.sh
+++ b/_deploy.sh
@@ -16,7 +16,7 @@ git clone -b gh-pages \
   book-output
 
 # Copy locally built *.html files into 
-cp -r slides.html book-output/
+cp -r index.html book-output/
 
 
 # Create .nojekyll file to prevent git from trying to build
@@ -26,5 +26,5 @@ touch book-output/.nojekyll
 # Add the locally built files to a commit and push
 cd book-output
 git add . -f
-git commit -m "Automatic build update" || true
+git commit -m "chore: automatic build update" || true
 git push origin gh-pages


### PR DESCRIPTION
# Summary
This PR attempts to get the CI pipeline working on [travis](https://travis-ci.org).

# Changes
- Update *shell* scripts to pull markdown slides from `_docs/` folder so that we don't get the `README.md` file being the GitHub page.

# Check
- [ ] The CI build on the eventual `master` branch when it is merged is successful.

# Note
This "fixes #5", hopefully...